### PR TITLE
make fresh: removes failed, successful and running containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,9 @@ $(DOCKER):
 
 $(DOCKER_PULL):
 	DOCKER_OPTS="$(DOCKER_OPTS)" make -C $(patsubst %-pull,%,$@) pull
+
+fresh:
+	$(shell docker ps    | tail -n+2 | awk '{print $$1}' | xargs docker kill >/dev/null 2>&1 || true )
+	$(shell docker ps -a | tail -n+2 | awk '{print $$1}' | xargs docker rm >/dev/null 2>&1 || true )
+	$(shell docker images | grep failed | awk '{print $$1,":",$$2}' | sed 's/ //g' | xargs docker rmi >/dev/null 2>&1 || true )
+	$(shell docker images | grep successful | awk '{print $$1,":",$$2}' | sed 's/ //g' | xargs docker rmi >/dev/null 2>&1 || true )

--- a/README.md
+++ b/README.md
@@ -236,6 +236,17 @@ Once done, one can removed failed containers by running `docker rmi art/foo:tag`
 or `ansible-role-test snapshots rm art/foo:tag`. A faster way to remove all
 the corresponding images is to run `ansible-role-test snapshots purge`.
 
+## Removing containers
+
+When using the `--save` options, the amount of `failed` and `successful` images can 
+build up.
+
+To remove the `failed`, `successful` and running containers, execute the following:
+
+```
+$ make fresh
+```
+
 ## Paths and config file
 
 Most of the time, your roles might depend on other local roles or plugins, in


### PR DESCRIPTION
I needed a simple command to clear out all the `failed` and `successful` containers when testing.
