### PR TITLE
Add support for docker 1.12+ API 1.24

### DIFF
--- a/ansibleroletest/container.py
+++ b/ansibleroletest/container.py
@@ -21,7 +21,10 @@ class Container(object):
         self._client = client
         self._props = {
             'image': image,
-            'detach': detach
+            'detach': detach,
+            'host_config': {
+                'NetworkMode': 'default'
+            }
         }
         self._props.update(options)
         self._host_ip = None

--- a/ansibleroletest/test.py
+++ b/ansibleroletest/test.py
@@ -269,18 +269,17 @@ class Test(object):
             if '/' not in full_image:
                 full_image = 'aeriscloud/ansible-%s' % info['image']
 
+            # this binding allows systemd to properly start in a container
+            bindings = [':'.join(['/sys/fs/cgroup', '/sys/fs/cgroup', 'ro'])]
+
             # we need to create the VM first as images are pulled at that time
             container = self.docker.create(name, image=full_image,
-                                           progress=pull_image_progress())
+                                           progress=pull_image_progress(),
+                                           host_config={
+                                              'Binds': bindings,
+                                              'Privileged': privileged
+                                           })
 
-            # this binding allows systemd to properly start in a container
-            bindings = {
-                '/sys/fs/cgroup': {'bind': '/sys/fs/cgroup', 'ro': True},
-            }
-
-            container.start(
-                binds=bindings,
-                privileged=privileged
-            )
+            container.start()
             info['container'] = container
             click.secho('ok: [%s]' % full_image, fg='green')

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from ansibleroletest import __version__, __author__, __email__, __license__, __u
 install_requires = [
     'appdirs >= 1.4.0, < 2.0',
     'click >= 4.0, < 5.0',
-    'docker-py >= 1.2.0, < 1.3',
+    'docker-py >= 1.10.0, < 1.11',
     'giturlparse.py == 0.0.5',
     'humanize >= 0.5, < 0.6',
     'python-slugify >= 1.0.2, < 2.0',


### PR DESCRIPTION
So since docker 1.10 host config should not be passed to `client.start` anymore, only in `client.create`. It was only deprecated so it worked all this time but API 1.24 will now break hard with 400 errors, preventing ART to work correctly.

For more details on the `HostConfig` stuff, see https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/
